### PR TITLE
building-from-source.md: Add libpcap instructions to Linux, MacOS

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -26,7 +26,7 @@ First install the [Homebrew package manager](https://brew.sh/).
 ```bash
 # Install dependencies
 brew update
-brew install coreutils pkg-config dylibbundler ninja
+brew install coreutils pkg-config dylibbundler libpcap ninja
 
 # Clone and build
 git clone https://github.com/mborgerson/xemu.git

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -26,7 +26,7 @@ First install the [Homebrew package manager](https://brew.sh/).
 ```bash
 # Install dependencies
 brew update
-brew install coreutils pkg-config dylibbundler libpcap ninja
+brew install coreutils pkg-config dylibbundler ninja
 
 # Clone and build
 git clone https://github.com/mborgerson/xemu.git

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -43,7 +43,7 @@ open ./dist/xemu.app
 ```bash
 # Install dependencies
 sudo apt update
-sudo apt install build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev ninja-build
+sudo apt install build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build
 
 # Clone and build
 git clone https://github.com/mborgerson/xemu.git


### PR DESCRIPTION
Seems that libpcap instructions haven't been added yet to the sites wiki, added both for Linux and MacOS as they are just an extra package in their instructions, opted not to add npcap as it is listing in Networking in the wiki