### PR TITLE
building-from-source.md: Add Arch Linux Instructions

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -39,17 +39,33 @@ open ./dist/xemu.app
 
 ## Linux
 
-### Debian/Ubuntu
-```bash
-# Install dependencies
-sudo apt update
-sudo apt install build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build
+=== "Debian/Ubuntu"
 
-# Clone and build
-git clone https://github.com/mborgerson/xemu.git
-cd xemu
-./build.sh
+    ```bash
+    # Install dependencies
+    sudo apt update
+    sudo apt install build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build
 
-# Run
-./dist/xemu
-```
+    # Clone and build
+    git clone https://github.com/mborgerson/xemu.git
+    cd xemu
+    ./build.sh
+
+    # Run
+    ./dist/xemu
+    ```
+
+=== "Arch Linux"
+
+    ```bash
+    # Install dependencies
+    sudo pacman -S --noconfirm base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu
+
+    # Clone and build
+    git clone https://github.com/mborgerson/xemu.git
+    cd xemu
+    ./build.sh
+
+    # Run
+    ./dist/xemu
+    ```

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -10,5 +10,5 @@ startup behavior.
 
 ## Advanced
 
-Extra command line arguments are passed as QEMU launch arguments. See QEMU
-documentation for specifics.
+Extra command line arguments are passed as QEMU launch arguments. See [QEMU
+documentation](https://www.qemu.org/documentation/) for specifics.


### PR DESCRIPTION
This is the revised and fixed version of Arch Linux build instructions on the wiki. Tested and everything works as it should. (note: also added a link to qemu documentation into this PR)