### PR TITLE
ftp.md: Add NevolutionX related link

### DIFF
--- a/docs/docs/ftp.md
+++ b/docs/docs/ftp.md
@@ -35,6 +35,8 @@ image, load the disc image. You may need to reset the system to get it to
 load. Double check the networking settings for your dashboard to make sure
 that it is configured to use DHCP.
 
+See NevolutionX for a FOSS alternative dashboard that supports FTP [here](https://github.com/dracc/NevolutionX).
+
 ## Step 4: Connect using your FTP client
 The [Filezilla FTP client](https://filezilla-project.org/) is recommended. It
 is an open-source client available for all major platforms. If you would


### PR DESCRIPTION
This aims to add NevoX as a link on the ftp.md page, as over the past few weeks I've saw about 5-8 or so questions asking which dash supports ftp, and adding a FOSS alternative dash that already comes in .iso format further eases the pretty lengthy amount of work you have to do to use this emulator.

Note: This can probably be reworded, I assume you will probably reword this if you find that necessary