### PR TITLE
ftp.md: Append Simultaneous Connections to Filezilla instructions

### DIFF
--- a/docs/docs/ftp.md
+++ b/docs/docs/ftp.md
@@ -54,6 +54,7 @@ Site</kbd> button.
 * For "Logon Type" select "Normal"
 * Enter the appropriate "User" and "Password" (typically `xbox` for both)
 * Navigate to the "Transfer Settings" tab and select "Active"
+* Check "Limit number of simultaneous connections" and set Max Connections to 1
 * Click <kbd>OK</kbd> when you are finished
 
 We must configure one more additional setting.


### PR DESCRIPTION
The original xbox (by proxy xemu) has issues with negotiating simultaneous connections via FTP. For example in UnleashX, it adds a "user" everytime a connection is made, and will bug and continue to add users on file transfers. Transferring multiple files also tends to have issues and fail, but transferring the same group of files one at a time doesn't have the same effect and will transfer smoothly.

I have done some thorough testing of transferring files between dashes and this seems to be an issue of most of the alternative dashes that I have tested.