### PR TITLE
building-from-source.md: Add git to dependencies

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -44,7 +44,7 @@ open ./dist/xemu.app
     ```bash
     # Install dependencies
     sudo apt update
-    sudo apt install build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build
+    sudo apt install git build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build
 
     # Clone and build
     git clone https://github.com/mborgerson/xemu.git
@@ -59,7 +59,7 @@ open ./dist/xemu.app
 
     ```bash
     # Install dependencies
-    sudo pacman -S --noconfirm base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu
+    sudo pacman -S --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu
 
     # Clone and build
     git clone https://github.com/mborgerson/xemu.git


### PR DESCRIPTION
Git isn't in the dependencies list upon install, some users will likely just copy the list to their clipboard and paste it in the terminal, for linux flavors like debian 11, git doesn't come preinstalled and someone who just picked up linux just to use xemu (which we've observed before) may not know what to do to get it working.