### PR TITLE
Added instructions for setting C/C++ compiler flags when building xemu

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -94,3 +94,17 @@ open ./dist/xemu.app
     ```bash
     CC=clang CXX=clang++ CC_LD=lld CXX_LD=lld AR=llvm-ar ./build.sh
     ```
+
+!!! tip "Tip: Passing build flags to the C/C++ compiler"
+
+    Extra build flags can be passed to the C/C++ compiler by using environment
+    variables in a similar manner to changing toolchains. The CFLAGS variable
+    sets C compiler flags and the CXXFLAGS variable sets C++ compiler flags.
+    Multiple flags can be set by separating them with a space, just be sure to
+    surround it in quotations. For example, if you wanted to build xemu with
+    extra optimizations for your specific CPU then you would invoke build.sh
+    as follows:
+
+    ```bash
+    CFLAGS="-march=native" CXXFLAGS="-march=native" ./build.sh
+    ```


### PR DESCRIPTION
In the xemu discord I suggested adding some instructions on the "Building from Source" page for setting compiler flags when building xemu. Matt asked me to submit a pull request so here it is.

I used `-march=native` as an example flag because that seemed like a relatively harmless example that someone could try and still compile successfully. I tested it myself and ran a few games and it worked well for me. I'm no xemu or C/C++ expert so I'm sorry if this example is more dangerous than it initially seems.