### PR TITLE
disc-images.md: Clarified xiso versus .iso

### DIFF
--- a/docs/docs/disc-images.md
+++ b/docs/docs/disc-images.md
@@ -1,4 +1,6 @@
-xemu requires game discs to be in the form of `*.iso` disc images.
+xemu requires game discs to be in the form of xiso images. These are generally
+saved with a `.iso` extension, but are not the same as typical ISO images and
+should be created following the instructions below.
 
 !!! warning "Disclaimer"
 


### PR DESCRIPTION
Expands description around the use of xiso to attempt to resolve confusion around xiso versus "normal" ISO.