### PR TITLE
Change name for Braveknight

### DIFF
--- a/titles/IL/002/info.json
+++ b/titles/IL/002/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "Braveknight: Leverant Eiyuuden",
+    "name": "Braveknight: Lieveland Eiyuuden",
     "title_id": "494c0002",
     "releases": [
         {


### PR DESCRIPTION
Changes title from "Braveknight: Leverant Eiyuuden" to "Braveknight: Lieveland Eiyuuden".

リーヴェラント is written as "Lieveland" in official materials, and "Leverant" is not a standard romanization.

http://www.panther.co.jp/brave/index.htm

