### PR TITLE
Update controller documentation to remove remapping section

### DIFF
--- a/docs/docs/controller.md
+++ b/docs/docs/controller.md
@@ -2,7 +2,6 @@ Built with SDL3, xemu supports virtually all gamepads. Connect up to 4
 controllers at any time, just like a real Xbox.
 
 !!! note "Notes & FAQ"
-    * There is currently no interface within xemu to adjust the keybindings.
     * Hot plugging works on Windows and Linux. It is broken on macOS.
     * USB passthru is not supported yet, but it will be coming.
     * Only the Xbox controller is emulated. There is not (yet) support for other controllers like the Steel Batallion.
@@ -42,7 +41,7 @@ additional installation of drivers or configuration is required.
 
 ## Keyboard as Gamepad
 
-The keyboard layout for the gamepad is:
+The default keyboard layout for the gamepad is:
 
 | Keyboard  | Gamepad       | Keyboard  | Gamepad       |
 |-----------|---------------|-----------|---------------|
@@ -62,18 +61,4 @@ The keyboard layout for the gamepad is:
        E                     I
     S     F               J     L
        D                     K
-```
-
-### Remapping keyboard buttons (advanced)
-
-The keyboard layout may be changed by editing the `xemu.toml` configuration file.
-
-SDL scancodes are used to define each key. They are defined [in the SDL project here](https://github.com/libsdl-org/SDL/blob/2ef79441701c87c801fe0e1456321a791f4b2faf/include/SDL3/SDL_scancode.h#L52)
-
-The names of the buttons in the config file may be found [in the xemu config spec here](https://github.com/xemu-project/xemu/blob/e02e41ccaaceffcad816cfb554dd1195767e952d/config_spec.yml#L61)
-
-For example, this changes the `A` button from `A` (scancode `4`) to `Q` (scancode `20`)
-```
-[input.keyboard_controller_scancode_map]
-a = 20
 ```


### PR DESCRIPTION
Removed advanced remapping instructions for keyboard buttons. You can do this in the gui now