### PR TITLE
Add missing Ubuntu build dependency

### DIFF
--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -53,7 +53,7 @@ open ./dist/xemu.app
     ```bash
     # Install dependencies
     sudo apt update
-    sudo apt install git build-essential cmake libsdl2-dev libcurl4-gnutls-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-pip python3-tomli python3-yaml libslirp-dev libvulkan-dev
+    sudo apt install git build-essential cmake libsdl2-dev libcurl4-gnutls-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-pip python3-tomli python3-yaml libslirp-dev libvulkan-dev libpipewire-0.3-dev
 
     # Clone and build
     git clone --recurse-submodules https://github.com/xemu-project/xemu.git


### PR DESCRIPTION
Building in Ubuntu on WSL fails with the following even though pipewire appears to be disabled...

```
Dependency libpipewire-0.3 skipped: feature pipewire disabled
```

```
sdl3| Run-time dependency libpipewire-0.3 found: NO (tried pkgconfig and cmake)

../subprojects/SDL3-3.4.0/meson.build:312:14: ERROR: Dependency "libpipewire-0.3" not found, tried pkgconfig and cmake

A full log can be found at /root/projects/xemu/build/meson-logs/meson-log.txt

ERROR: meson setup failed
```