### PR TITLE
Fixed SDL ver and controller URL

### DIFF
--- a/templates/template_index.html
+++ b/templates/template_index.html
@@ -303,7 +303,7 @@
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fas fa-gamepad feature-icon"></i>Controller Support</h4>
-        <p>Built on <a href="https://www.libsdl.org/">SDL2</a>, xemu supports virtually all controllers. Connect up to 4 controllers at any time, just like a real Xbox. Learn more <a href="/docs/input/">here</a>.</p>
+        <p>Built on <a href="https://www.libsdl.org/">SDL3</a>, xemu supports virtually all controllers. Connect up to 4 controllers at any time, just like a real Xbox. Learn more <a href="/docs/controller/">here</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">


### PR DESCRIPTION
Just a couple of things I noticed while browsing the site.

By the way, I don't know if https://xemu.app/docs/input/ *used* to be a valid URL, but if it was, maybe you might consider setting up a redirect too, to fix any off-site incoming links.