### PR TITLE
Improve the "learn more here" links

### DIFF
--- a/templates/template_index.html
+++ b/templates/template_index.html
@@ -285,13 +285,13 @@
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fab fa-github feature-icon"></i>Open Source</h4>
-        <p>The source code for xemu is available on <a href="https://github.com/xemu-project/xemu">GitHub</a>. You are invited to help improve the project! Learn more <a href="/docs/dev/">here</a>.</p>
+        <p>The source code for xemu is available on <a href="https://github.com/xemu-project/xemu">GitHub</a>. You are invited to help improve the project! <a href="/docs/dev/">Learn more</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fas fa-users feature-icon"></i>Cross Platform</h4>
-        <p>xemu runs natively on Windows, macOS, and Linux platforms. Binaries are available for all platforms, or you can build from source if desired. Learn more <a href="/docs/download/">here</a>.</p>
+        <p>xemu runs natively on Windows, macOS, and Linux platforms. Binaries are available for all platforms, or you can build from source if desired. <a href="/docs/download/">Learn more</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">
@@ -303,13 +303,13 @@
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fas fa-gamepad feature-icon"></i>Controller Support</h4>
-        <p>Built on <a href="https://www.libsdl.org/">SDL3</a>, xemu supports virtually all controllers. Connect up to 4 controllers at any time, just like a real Xbox. Learn more <a href="/docs/controller/">here</a>.</p>
+        <p>Built on <a href="https://www.libsdl.org/">SDL3</a>, xemu supports virtually all controllers. Connect up to 4 controllers at any time, just like a real Xbox. <a href="/docs/controller/">Learn more</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fas fa-history feature-icon"></i>Snapshots (Save States)</h4>
-        <p>No need to wait for game checkpoints. xemu supports saving the current machine state and loading it back up at any time. Learn more <a href="/docs/snapshots/">here</a>.</p>
+        <p>No need to wait for game checkpoints. xemu supports saving the current machine state and loading it back up at any time. <a href="/docs/snapshots/">Learn more</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">
@@ -321,7 +321,7 @@
     <div class="col-md-6 p-1">
       <div class="feature-card">
         <h4><i class="fas fa-people-arrows feature-icon"></i>Networking</h4>
-        <p>Connect to other instances of xemu and real Xboxes, locally or over the Internet. Supports tunneling services and Xbox Live recreation projects. Learn more <a href="/docs/networking/">here</a>.</p>
+        <p>Connect to other instances of xemu and real Xboxes, locally or over the Internet. Supports tunneling services and Xbox Live recreation projects. <a href="/docs/networking/">Learn more</a>.</p>
       </div>
     </div>
     <div class="col-md-6 p-1">


### PR DESCRIPTION
I always think "here" links look messy. Changed to link just "Learn more" instead.