### PR TITLE
Add save game clarification to Snapshots documentation

### DIFF
--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -1,20 +1,34 @@
-**Snapshots**, also often called *Save States*, are a representation of the entire machine state which can be saved or restored at any time. With snapshots you can virtually eliminate the need to rely on in-game checkpoints to save your progress. Save a snapshot, and load it up again later and it's as if you had just kept on playing.
+**Snapshots**, also often called *Save States*, are a representation of the entire machine state which can be saved or restored at
+any time. With snapshots you can virtually eliminate the need to rely on in-game checkpoints to save your progress. Save a snapshot,
+and load it up again later and it's as if you had just kept on playing.
 
 !!! warning
 
-	Please be aware that snapshots are a brand new feature. While this feature works reliably in my testing, there may be some bugs. There are some caveats to be aware of.
+	Snapshots are built on top of QEMU and may behave differently from save states in other emulators. There are some caveats
+        to be aware of. Please read the following carefully.
 
 ## About Snapshots
 
-Snapshots are saved to the hard disk image that you started xemu with.
+Snapshots are saved to the hard disk image that you started xemu with. They capture the full state of the machine, including any
+loaded disc, attached controllers, and hard drive state.
 
 !!! danger "Important Notes"
 
 	Before restoring a snapshot, you should:
 
-	* **If using the monitor, load your game disc image as normal.** Loading a snapshot from the monitor will not re-mount the game disc, so if you load a snapshot and the game then tries to read from disc, it will fail. Launch xemu, load your game disc, then restore the snapshot. Loading a snapshot from the UI will prompt to remount the disc, so this step is not needed.
+	* **If using the monitor, load your game disc image as normal.** Loading a snapshot from the monitor will not re-mount the
+	game disc, so if you load a snapshot and the game then tries to read from disc, it will fail. Launch xemu, load your game disc,
+	then restore the snapshot. Loading a snapshot from the UI will prompt to remount the disc, so this step is not needed.
 
-	* **Connect controllers to match the saved configuration.** For instance: if there was a controller connected to Port 1 when the snapshot was created, make sure there is a controller connected to Port 1 before loading the snapshot. If this configuration does not match, an error message will be displayed and the machine will be paused. Simply connect the appropriate controllers, load the snapshot again, and enter `cont` in the monitor to continue).
+	* **Connect controllers to match the saved configuration.** For instance: if there was a controller connected to Port 1
+	when the snapshot was created, make sure there is a controller connected to Port 1 before loading the snapshot. If this
+	configuration does not match, an error message will be displayed and the machine will be paused. Simply connect the
+	appropriate controllers, load the snapshot again, and enter `cont` in the monitor to continue).
+
+!!! warning
+
+	Since the Xbox generally stores in-game saves on the hard disk, using snapshots may affect the visibility of saved games.
+	For example, a newly saved game will not be present if you revert to an older snapshot.
 
 ## Using the UI
 


### PR DESCRIPTION
The interaction between saved games within the guest and snapshots is unusual compared to most emulator save states. This change attempts to clarify this and removes the stale language about snapshots being brand new.

Also cleans up formatting in the file slightly.